### PR TITLE
Feature: markdown table

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ func main() {
 	tree := flag.Bool("tree", false, "[Optional] print changes in tree format")
 	separateTree := flag.Bool("separate-tree", false, "[Optional] print changes in tree format for add/delete/change/recreate changes")
 	drawable := flag.Bool("draw", false, "[Optional, used only with -tree or -separate-tree] draw trees instead of plain tree")
+	md := flag.Bool("md", false, "[Optional, used only with table view] output table as markdown")
 	outputFileName := flag.String("out", "", "[Optional] write output to file")
 
 	flag.Usage = func() {
@@ -32,7 +33,7 @@ func main() {
 	}
 
 	args := flag.Args()
-	err := validateFlags(*tree, *separateTree, *drawable, args)
+	err := validateFlags(*tree, *separateTree, *drawable, *md, args)
 	logIfErrorAndExit("invalid input flags: %s\n", err, flag.Usage)
 
 	newReader, err := reader.CreateReader(os.Stdin, args)
@@ -49,7 +50,7 @@ func main() {
 
 	terraformState.FilterNoOpResources()
 
-	newWriter := writer.CreateWriter(*tree, *separateTree, *drawable, terraformState)
+	newWriter := writer.CreateWriter(*tree, *separateTree, *drawable, *md, terraformState)
 
 	var outputFile io.Writer = os.Stdout
 
@@ -80,7 +81,13 @@ func logIfErrorAndExit(format string, err error, callback func()) {
 	}
 }
 
-func validateFlags(tree, separateTree, drawable bool, args []string) error {
+func validateFlags(tree, separateTree, drawable bool, md bool, args []string) error {
+	if tree && md {
+		return fmt.Errorf("both -tree and -md should not be provided")
+	}
+	if separateTree && md {
+		return fmt.Errorf("both -seperate-tree and -md should not be provided")
+	}
 	if tree && separateTree {
 		return fmt.Errorf("both -tree and -seperate-tree should not be provided")
 	}

--- a/reader/stdin.go
+++ b/reader/stdin.go
@@ -5,6 +5,7 @@ import (
 )
 
 const StdinFileName = "stdin"
+
 type StdinReader struct {
 }
 

--- a/writer/table.go
+++ b/writer/table.go
@@ -1,33 +1,50 @@
 package writer
 
 import (
-	"github.com/olekukonko/tablewriter"
+	"fmt"
 	"io"
 	"terraform-plan-summary/terraform_state"
+
+	"github.com/olekukonko/tablewriter"
 )
 
 type TableWriter struct {
-	changes map[string]terraform_state.ResourceChanges
+	mdEnabled bool
+	changes   map[string]terraform_state.ResourceChanges
 }
 
 func (t TableWriter) Write(writer io.Writer) error {
 	tableString := make([][]string, 0, 4)
 	for change, changedResources := range t.changes {
 		for _, changedResource := range changedResources {
-			tableString = append(tableString, []string{change, changedResource.Address})
+			if t.mdEnabled {
+				tableString = append(tableString, []string{change, fmt.Sprintf("`%s`", changedResource.Address)})
+			} else {
+				tableString = append(tableString, []string{change, changedResource.Address})
+			}
 		}
 	}
 
 	table := tablewriter.NewWriter(writer)
 	table.SetHeader([]string{"Change", "Name"})
 	table.SetAutoMergeCells(true)
-	table.SetRowLine(true)
 	table.AppendBulk(tableString)
+
+	if t.mdEnabled {
+		table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+		table.SetCenterSeparator("|")
+	} else {
+		table.SetRowLine(true)
+	}
+
 	table.Render()
 
 	return nil
 }
 
-func NewTableWriter(changes map[string]terraform_state.ResourceChanges) Writer {
-	return TableWriter{changes: changes}
+func NewTableWriter(changes map[string]terraform_state.ResourceChanges, mdEnabled bool) Writer {
+	return TableWriter{
+		changes:   changes,
+		mdEnabled: mdEnabled,
+	}
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -9,12 +9,12 @@ type Writer interface {
 	Write(writer io.Writer) error
 }
 
-func CreateWriter(tree, separateTree, drawable bool, terraformState terraform_state.TerraformState) Writer {
+func CreateWriter(tree, separateTree, drawable bool, mdEnabled bool, terraformState terraform_state.TerraformState) Writer {
 	if tree {
 		return NewTreeWriter(terraformState.ResourceChanges, drawable)
 	}
 	if separateTree {
 		return NewSeparateTree(terraformState.AllChanges(), drawable)
 	}
-	return NewTableWriter(terraformState.AllChanges())
+	return NewTableWriter(terraformState.AllChanges(), mdEnabled)
 }


### PR DESCRIPTION
```bash
tf-summarize -md tfplan
```

returns markdown like this:

| CHANGE |                                       NAME                                       |
|--------|----------------------------------------------------------------------------------|
| add    | `module.test-only.github_branch_protection_v3.branch_protection[0]`              |
|        | `module.test-only.github_repository.repository`                                  |
|        | `module.test-only.github_team_repository.team_repository_by_slug["xxxxxx"]`      |
|        | `module.test-only.github_team_repository.team_repository_by_slug["yyyyyyyyyyy"]` |

Useful when sending summary as GitHub comment on PR