### PR TITLE
Fix the yaml syntax for the docker release in goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -26,16 +27,16 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
-          
-      - 
+
+      -
         name: Setup QEMU
         uses: docker/setup-qemu-action@v2
 
-      - 
+      -
         name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - 
+      -
         name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,21 +6,21 @@ before:
     - go mod tidy
 dockers:
 - dockerfile: Dockerfile
-    image_templates:
-      - ghcr.io/dineshba/tf-summarize:{{ .Version }}-amd64
-      - ghcr.io/dineshba/tf-summarize:latest-amd64
-    build_flag_templates:
-      - "--label=org.opencontainers.image.created={{ .Date }}"
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--platform=linux/amd64"
-      - "--target=goreleaser"
-      - "--pull"
-    goos: linux
-    goarch: amd64
-    goamd64: v1
-    use: buildx
+  image_templates:
+    - ghcr.io/dineshba/tf-summarize:{{ .Version }}-amd64
+    - ghcr.io/dineshba/tf-summarize:latest-amd64
+  build_flag_templates:
+    - "--label=org.opencontainers.image.created={{ .Date }}"
+    - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+    - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+    - "--label=org.opencontainers.image.version={{ .Version }}"
+    - "--platform=linux/amd64"
+    - "--target=goreleaser"
+    - "--pull"
+  goos: linux
+  goarch: amd64
+  goamd64: v1
+  use: buildx
 builds:
   - env:
       # goreleaser does not work with CGO, it could also complicate

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,7 @@ dockers:
   image_templates:
     - ghcr.io/dineshba/tf-summarize:{{ .Version }}-amd64
     - ghcr.io/dineshba/tf-summarize:latest-amd64
+    - ghcr.io/dineshba/tf-summarize:latest
   build_flag_templates:
     - "--label=org.opencontainers.image.created={{ .Date }}"
     - "--label=org.opencontainers.image.title={{ .ProjectName }}"


### PR DESCRIPTION
1. Fix the yaml indentation
2. Added latest tag to docker image. This helps when user do `docker pull ghcr.io/dineshba/tf-summarize` (without any tags)