### PR TITLE
Enable Go Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [Demo](#demo)
 - [Why do we need it ?](#why-do-we-need-it-)
 - [Install](#install)
+  - [Using Go](#using-go)
   - [Using Brew](#using-brew)
   - [Using Docker](#using-docker)
   - [Download zip in release page](#download-zip-in-release-page)
@@ -34,6 +35,11 @@ If demo is slower for you, please see [examples](#examples) and [screenshot](#sc
 - When our plan have more than say 10 changes, we will first see what are the deleted changes, or we will just see the list of resources that get affected.
 
 ### Install
+
+#### Using Go
+```sh
+go install github.com/dineshba/tf-summarize@latest
+```
 
 #### Using Brew
 ```sh

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module terraform-plan-summary
+module github.com/dineshba/tf-summarize
 
 go 1.17
 

--- a/main.go
+++ b/main.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"terraform-plan-summary/parser"
-	"terraform-plan-summary/reader"
-	"terraform-plan-summary/writer"
+	"github.com/dineshba/tf-summarize/parser"
+	"github.com/dineshba/tf-summarize/reader"
+	"github.com/dineshba/tf-summarize/writer"
 )
 
 var version = "development"

--- a/parser/binary-parser.go
+++ b/parser/binary-parser.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
-	"terraform-plan-summary/terraform_state"
+	"github.com/dineshba/tf-summarize/terraform_state"
 )
 
 type BinaryParser struct {

--- a/parser/json-parser.go
+++ b/parser/json-parser.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"encoding/json"
 	"fmt"
-	"terraform-plan-summary/terraform_state"
+	"github.com/dineshba/tf-summarize/terraform_state"
 )
 
 type JsonParser struct {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -2,8 +2,8 @@ package parser
 
 import (
 	"strings"
-	"terraform-plan-summary/reader"
-	"terraform-plan-summary/terraform_state"
+	"github.com/dineshba/tf-summarize/reader"
+	"github.com/dineshba/tf-summarize/terraform_state"
 )
 
 type Parser interface {

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -3,7 +3,7 @@ package tree
 import (
 	"fmt"
 	"strings"
-	"terraform-plan-summary/terraform_state"
+	"github.com/dineshba/tf-summarize/terraform_state"
 
 	"github.com/m1gwings/treedrawer/tree"
 )

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -1,7 +1,7 @@
 package tree
 
 import (
-	"terraform-plan-summary/terraform_state"
+	"github.com/dineshba/tf-summarize/terraform_state"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/writer/json.go
+++ b/writer/json.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"terraform-plan-summary/terraform_state"
-	"terraform-plan-summary/tree"
+	"github.com/dineshba/tf-summarize/terraform_state"
+	"github.com/dineshba/tf-summarize/tree"
 
 	"github.com/nsf/jsondiff"
 )

--- a/writer/separate_tree.go
+++ b/writer/separate_tree.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"terraform-plan-summary/terraform_state"
+	"github.com/dineshba/tf-summarize/terraform_state"
 )
 
 const SEPARATOR = "###################"

--- a/writer/table.go
+++ b/writer/table.go
@@ -3,7 +3,7 @@ package writer
 import (
 	"fmt"
 	"io"
-	"terraform-plan-summary/terraform_state"
+	"github.com/dineshba/tf-summarize/terraform_state"
 
 	"github.com/olekukonko/tablewriter"
 )

--- a/writer/tree.go
+++ b/writer/tree.go
@@ -3,8 +3,8 @@ package writer
 import (
 	"fmt"
 	"io"
-	"terraform-plan-summary/terraform_state"
-	"terraform-plan-summary/tree"
+	"github.com/dineshba/tf-summarize/terraform_state"
+	"github.com/dineshba/tf-summarize/tree"
 )
 
 type TreeWriter struct {

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -2,7 +2,7 @@ package writer
 
 import (
 	"io"
-	"terraform-plan-summary/terraform_state"
+	"github.com/dineshba/tf-summarize/terraform_state"
 )
 
 type Writer interface {


### PR DESCRIPTION
Hi @dineshba this is a cool tool that I would like to use more of.

I think it would help a few people a lot if they would install this with the `go install` command: https://pkg.go.dev/cmd/go#hdr-Compile_and_install_packages_and_dependencies

Unfortunately, right now when I try to do that, this happens:
```
🕙 12:40:08 ❯ go install github.com/dineshba/tf-summarize@latest
go: github.com/dineshba/tf-summarize@latest: github.com/dineshba/tf-summarize@v0.2.5: parsing go.mod:
	module declares its path as: terraform-plan-summary
	        but was required as: github.com/dineshba/tf-summarize
```

I believe that to fix it, you need the name of the ~~package~~ module to match the address of the repository, so I made this PR.

I also tested it on my fork:
```
🕙 12:47:48 ❯ tf-summarize
fish: Unknown command: tf-summarize
~
🕙 12:47:56 ❯ go install github.com/triarius/tf-summarize@latest
🕙 12:48:03 ❯ tf-summarize -help
Usage of tf-summarize [args] [tf-plan.json|tfplan]

  -draw
    	[Optional, used only with -tree or -separate-tree] draw trees instead of plain tree
  -json
    	[Optional] print changes in json format
  -md
    	[Optional, used only with table view] output table as markdown
  -out string
    	[Optional] write output to file
  -separate-tree
    	[Optional] print changes in tree format for add/delete/change/recreate changes
  -tree
    	[Optional] print changes in tree format
  -v	print version
```

I don't think it should interfere with your CI, but if it does, I'll be happy to work with you to fix it.