### PR TITLE
Added in Codefresh Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ We need to output the plan to json as there were some strange issues on codefres
       - tf-summarize output.json
 ```
 
-> :warning: **Not maintained by [dineshba](https://github.com/dineshba) **: The above example is maintained by [userbradley](https://github.com/userbradley) - Any questions related please tag `@userbradley` on an issue 
+> :warning: ** Not maintained by [dineshba](https://github.com/dineshba) **: The above example is maintained by [userbradley](https://github.com/userbradley) - Any questions related please tag `@userbradley` on an issue 
 
 #### Comment terraform plan summary in PRs
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ The below assumes that you have a stage called `show` in your `codefresh.yaml` e
 
 We need to output the plan to json as there were some strange issues on codefresh when we used the `tfplan` file
 
+A full example is available at [`example/codefresh/codefresh.yaml`](/example/codefresh/codefresh.yaml)
+
 ```yaml
   TerraformPlan:
     title: Terraform Plan

--- a/README.md
+++ b/README.md
@@ -7,24 +7,26 @@
 
 `tf-summarize` is a command-line utility to print the summary of the terraform plan
 
-- [tf-summarize (Terraform Summarizer)](#tf-summarize-terraform-summarizer)
-  - [Demo](#demo)
-  - [Why do we need it ?](#why-do-we-need-it-)
-  - [Install](#install)
-    - [Using Go](#using-go)
-    - [Using Brew](#using-brew)
-    - [Using asdf](#using-asdf)
-    - [Using Docker](#using-docker)
-    - [Download zip in release page](#download-zip-in-release-page)
-    - [Clone and Build Binary](#clone-and-build-binary)
-  - [Usage](#usage)
-  - [Examples](#examples)
-    - [Github Actions Workflow](#github-actions-workflow)
-    - [Comment terraform plan summary in PRs](#comment-terraform-plan-summary-in-prs)
-    - [Interactive summary review](#interactive-summary-review)
-  - [Screenshot](#screenshot)
-  - [TODO](#todo)
-
+<!-- TOC -->
+  * [tf-summarize (Terraform Summarizer)](#tf-summarize--terraform-summarizer-)
+    * [Demo](#demo)
+    * [Why do we need it ?](#why-do-we-need-it-)
+    * [Install](#install)
+      * [Using Go](#using-go)
+      * [Using Brew](#using-brew)
+      * [Using asdf](#using-asdf)
+      * [Using Docker](#using-docker)
+      * [Download zip in release page](#download-zip-in-release-page)
+      * [Clone and Build Binary](#clone-and-build-binary)
+    * [Usage](#usage)
+    * [Examples](#examples)
+      * [GitHub Actions Workflow](#github-actions-workflow)
+      * [Codefresh example](#codefresh-example)
+      * [Comment terraform plan summary in PRs](#comment-terraform-plan-summary-in-prs)
+      * [Interactive summary review](#interactive-summary-review)
+    * [Screenshot](#screenshot)
+    * [TODO](#todo)
+<!-- TOC -->
 ### Demo
 
 ![demo](example/demo.gif)

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ We need to output the plan to json as there were some strange issues on codefres
       - tf-summarize output.json
 ```
 
-> :warning: ** Not maintained by [dineshba](https://github.com/dineshba) **: The above example is maintained by [userbradley](https://github.com/userbradley) - Any questions related please tag `@userbradley` on an issue 
+> :warning: **Not maintained by [dineshba](https://github.com/dineshba)** : The above example is maintained by [userbradley](https://github.com/userbradley) - Any questions related please tag `@userbradley` on an issue 
 
 #### Comment terraform plan summary in PRs
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,33 @@ Please refer this sample [GitHub actions file](.github/workflows/demo.yml) and t
 
 > Note: If you are using `hashicorp/setup-terraform` GitHub action to set up terraform, ensure terraform_wrapper is set to false.
 
+#### Codefresh example
+
+The below assumes that you have a stage called `show` in your `codefresh.yaml` example
+
+We need to output the plan to json as there were some strange issues on codefresh when we used the `tfplan` file
+
+```yaml
+  TerraformPlan:
+    title: Terraform Plan
+    image: hashicorp/terraform:light
+    stage: plan
+    working_directory: "${{clone}}"
+    commands:
+      - terraform plan -out=tfplan
+      - terraform show -json tfplan > output.json
+  
+  tfSummarize:
+    title: Show Changes
+    image: ghcr.io/dineshba/tf-summarize
+    stage: show
+    working_directory: "${{clone}}"
+    commands:
+      - tf-summarize output.json
+```
+
+> :warning: **Not maintained by [dineshba](https://github.com/dineshba) **: The above example is maintained by [userbradley](https://github.com/userbradley) - Any questions related please tag `@userbradley` on an issue 
+
 #### Comment terraform plan summary in PRs
 
 Refer [this example](https://github.com/dineshba/tf-summarize/blob/demo-pr/.github/workflows/demo.yml#L61-L73) to add comments in your PR. Sample [comment](https://github.com/dineshba/tf-summarize/pull/19#issuecomment-1295882938) added by github actions bot.

--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ terraform show -json tfplan > output.json
 tf-summarize output.json                      # summary in table format
 ```
 
-#### Github Actions Workflow
+#### GitHub Actions Workflow
 
-Please refer this sample [github actions file](.github/workflows/demo.yml) and the sample runs [here](https://github.com/dineshba/tf-summarize/actions/workflows/demo.yml)
+Please refer this sample [GitHub actions file](.github/workflows/demo.yml) and the sample runs [here](https://github.com/dineshba/tf-summarize/actions/workflows/demo.yml)
 
-> Note: If you are using `hashicorp/setup-terraform` github action to setup terraform, ensure terraform_wrapper is set to false.
+> Note: If you are using `hashicorp/setup-terraform` GitHub action to set up terraform, ensure terraform_wrapper is set to false.
 
 #### Comment terraform plan summary in PRs
 

--- a/example/codefresh/codefresh.yaml
+++ b/example/codefresh/codefresh.yaml
@@ -17,21 +17,21 @@ steps:
     stage: "clone"
 
   TerraformInit:
-    image: hashicorp/terraform:1.3.8
+    image: hashicorp/terraform:light
     title: Terraform Init
     stage: init
     working_directory: "${{clone}}"
     cmd: init
 
   TerraformValidate:
-    image: hashicorp/terraform:1.3.8
+    image: hashicorp/terraform:light
     title: Terraform Validate
     stage: init
     working_directory: "${{clone}}"
     cmd: validate
 
   TerraformPlan:
-    image: hashicorp/terraform:1.3.8
+    image: hashicorp/terraform:light
     title: Terraform Plan
     stage: plan
     working_directory: "${{clone}}"
@@ -48,7 +48,7 @@ steps:
       - tf-summarize output.json
 
   TerraformApply:
-    image: hashicorp/terraform:1.3.8
+    image: hashicorp/terraform:light
     title: Terraform Apply from Plan
     stage: deploy
     working_directory: "${{clone}}"

--- a/example/codefresh/codefresh.yaml
+++ b/example/codefresh/codefresh.yaml
@@ -1,0 +1,56 @@
+# Created by Bradley of breadNET (bradley@breadnet.co.uk)
+version: "1.0"
+
+stages:
+  - "clone"
+  - "init"
+  - "plan"
+  - "show"
+  - "deploy"
+
+steps:
+  clone:
+    title: "Cloning repository"
+    type: "git-clone"
+    repo: "petsathome/terraform"
+    revision: "${{CF_BRANCH}}"
+    stage: "clone"
+
+  TerraformInit:
+    image: hashicorp/terraform:1.3.8
+    title: Terraform Init
+    stage: init
+    working_directory: "${{clone}}"
+    cmd: init
+
+  TerraformValidate:
+    image: hashicorp/terraform:1.3.8
+    title: Terraform Validate
+    stage: init
+    working_directory: "${{clone}}"
+    cmd: validate
+
+  TerraformPlan:
+    image: hashicorp/terraform:1.3.8
+    title: Terraform Plan
+    stage: plan
+    working_directory: "${{clone}}"
+    commands:
+      - terraform plan -out=tfplan
+      - terraform show -json tfplan > output.json
+  
+  tfSummarize:
+    title: Show Changes
+    image: ghcr.io/dineshba/tf-summarize
+    stage: show
+    working_directory: "${{clone}}"
+    commands:
+      - tf-summarize output.json
+
+  TerraformApply:
+    image: hashicorp/terraform:1.3.8
+    title: Terraform Apply from Plan
+    stage: deploy
+    working_directory: "${{clone}}"
+    commands:
+      - terraform apply tfplan


### PR DESCRIPTION
This pull request adds in the `Codefresh` example as discussed in #29 

I also fixed some spelling mistakes on `GitHub` (As shown in their [Logos](https://github.com/logos) they expect it up be uppercase)

I have made it clear with the below that this is not your step, and any issues users should tag @userbradley 

```markdown
> :warning: **Not maintained by [dineshba](https://github.com/dineshba)** : The above example is maintained by [userbradley](https://github.com/userbradley) - Any questions related please tag `@userbradley` on an issue
```

Which renders like:

> :warning: **Not maintained by [dineshba](https://github.com/dineshba)** : The above example is maintained by [userbradley](https://github.com/userbradley) - Any questions related please tag `@userbradley` on an issue