### PR TITLE
fix: Preserve new lines when buffering

### DIFF
--- a/writer/table.go
+++ b/writer/table.go
@@ -58,8 +58,8 @@ func (t TableWriter) Write(writer io.Writer) error {
 		table.AppendBulk(tableString)
 
 		if t.mdEnabled {
-			// Adding a println to break up the tables in md mode
-			fmt.Println()
+			// Adding a new line to break up the tables in md mode
+			writer.Write([]byte("\n"))
 			table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 			table.SetCenterSeparator("|")
 		} else {


### PR DESCRIPTION
Instead of writing a `println()` which prints to stdout, write the new line character tot he `io.Writer`, this way it is preserved, otherwise, the character is lost.

This way, the code of `tf-summarize` can be used as a library inside your Go code rather than a executable binary and the expected output is the same.

Simple test code:
```
package main

import (
	"bytes"
	"os"

	"github.com/dineshba/tf-summarize/parser"
	"github.com/dineshba/tf-summarize/reader"
	"github.com/dineshba/tf-summarize/writer"
)

func main() {
	planOutputFile := "/tmp/plan"
	newReader, err := reader.CreateReader(os.Stdin, []string{planOutputFile})
	if err != nil {
		panic(err)
	}
	input, err := newReader.Read()
	newParser, err := parser.CreateParser(input, newReader.Name())
	terraformState, err := newParser.Parse()
	if err != nil {
		panic(err)
	}
	terraformState.FilterNoOpResources()
	newWriter := writer.CreateWriter(false, false, false, true, false, terraformState)

	var b bytes.Buffer
	newWriter.Write(&b)

	println(b.String())

}
```