### PR TITLE
Add order to table output

### DIFF
--- a/writer/table.go
+++ b/writer/table.go
@@ -14,9 +14,12 @@ type TableWriter struct {
 	outputChanges map[string][]string
 }
 
+var tableOrder = []string{"import", "add", "delete", "update", "recreate"}
+
 func (t TableWriter) Write(writer io.Writer) error {
 	tableString := make([][]string, 0, 4)
-	for change, changedResources := range t.changes {
+	for _, change := range tableOrder {
+		changedResources := t.changes[change]
 		for _, changedResource := range changedResources {
 			if t.mdEnabled {
 				tableString = append(tableString, []string{change, fmt.Sprintf("`%s`", changedResource.Address)})
@@ -43,7 +46,8 @@ func (t TableWriter) Write(writer io.Writer) error {
 	// Disable the Output Summary if there are no outputs to display
 	if len(t.outputChanges["add"]) > 0 || len(t.outputChanges["delete"]) > 0 || len(t.outputChanges["update"]) > 0 {
 		tableString = make([][]string, 0, 4)
-		for change, changedOutputs := range t.outputChanges {
+		for _, change := range tableOrder {
+			changedOutputs := t.outputChanges[change]
 			for _, changedOutput := range changedOutputs {
 				if t.mdEnabled {
 					tableString = append(tableString, []string{change, fmt.Sprintf("`%s`", changedOutput)})

--- a/writer/table.go
+++ b/writer/table.go
@@ -14,7 +14,7 @@ type TableWriter struct {
 	outputChanges map[string][]string
 }
 
-var tableOrder = []string{"import", "add", "delete", "update", "recreate"}
+var tableOrder = []string{"import", "add", "update", "recreate", "delete"}
 
 func (t TableWriter) Write(writer io.Writer) error {
 	tableString := make([][]string, 0, 4)


### PR DESCRIPTION
Adds deterministic order to table output that mirrors the terraform plan numbered order (import, then add, change, destroy).

For example, if the terraform plan output states, "Plan: 2 to import, 3 to add, 1 to change, 1 to destroy.", the markdown table would be:

| CHANGE |                            RESOURCE                            |
|--------|---|
| import | `resource-1` |
| | `resource-2` |
| add | `resource-3` |
| | `resource-4` |
| | `resource-5` |
| update | `resource-6` |
| delete | `resource-7` |

Previously, this order was not deterministic.