### PR TITLE
Add import to outputs

### DIFF
--- a/terraformstate/terraform_state.go
+++ b/terraformstate/terraform_state.go
@@ -50,7 +50,7 @@ func (rc ResourceChange) ColorPrefixAndSuffixText() (string, string) {
 			colorPrefix = ColorYellow
 			suffix = "(~)"
 		}
-	} else if rc.Change.Importing.Id != "" {
+	} else if rc.Change.Importing.ID != "" {
 		colorPrefix = ColorCyan
 		suffix = "(i)"
 	} else {
@@ -101,7 +101,7 @@ func deletedResources(resources ResourceChanges) ResourceChanges {
 func importedResources(resources ResourceChanges) ResourceChanges {
 	acc := make(ResourceChanges, 0)
 	for _, r := range resources {
-		id := r.Change.Importing.Id
+		id := r.Change.Importing.ID
 		if id != "" {
 			acc = append(acc, r)
 		}
@@ -112,7 +112,7 @@ func importedResources(resources ResourceChanges) ResourceChanges {
 func (ts *TerraformState) FilterNoOpResources() {
 	acc := make(ResourceChanges, 0)
 	for _, r := range ts.ResourceChanges {
-		if len(r.Change.Actions) == 1 && r.Change.Actions[0] == "no-op" && r.Change.Importing.Id == "" {
+		if len(r.Change.Actions) == 1 && r.Change.Actions[0] == "no-op" && r.Change.Importing.ID == "" {
 			continue
 		}
 		acc = append(acc, r)

--- a/terraformstate/terraform_state.go
+++ b/terraformstate/terraform_state.go
@@ -10,6 +10,7 @@ const ColorRed = "\033[31m"
 const ColorGreen = "\033[32m"
 const ColorMagenta = "\033[35m"
 const ColorYellow = "\033[33m"
+const ColorCyan = "\033[36m"
 
 type ResourceChange struct {
 	Address       string `json:"address"`
@@ -19,9 +20,12 @@ type ResourceChange struct {
 	Name          string `json:"name"`
 	ProviderName  string `json:"provider_name"`
 	Change        struct {
-		Actions []string        `json:"actions"`
-		Before  json.RawMessage `json:"before,omitempty"`
-		After   json.RawMessage `json:"after,omitempty"`
+		Actions   []string        `json:"actions"`
+		Before    json.RawMessage `json:"before,omitempty"`
+		After     json.RawMessage `json:"after,omitempty"`
+		Importing struct {
+			Id string `json:"id"`
+		} `json:"importing"`
 	} `json:"change"`
 	ActionReason string `json:"action_reason,omitempty"`
 }
@@ -35,7 +39,7 @@ type OutputValues struct {
 func (rc ResourceChange) ColorPrefixAndSuffixText() (string, string) {
 	var colorPrefix, suffix string
 	actions := rc.Change.Actions
-	if len(actions) == 1 {
+	if len(actions) == 1 && actions[0] != "no-op" {
 		if actions[0] == "create" {
 			colorPrefix = ColorGreen
 			suffix = "(+)"
@@ -46,6 +50,9 @@ func (rc ResourceChange) ColorPrefixAndSuffixText() (string, string) {
 			colorPrefix = ColorYellow
 			suffix = "(~)"
 		}
+	} else if rc.Change.Importing.Id != "" {
+		colorPrefix = ColorCyan
+		suffix = "(i)"
 	} else {
 		colorPrefix = ColorMagenta
 		suffix = "(+/-)"
@@ -91,10 +98,21 @@ func deletedResources(resources ResourceChanges) ResourceChanges {
 	return filterResources(resources, "delete")
 }
 
+func importedResources(resources ResourceChanges) ResourceChanges {
+	acc := make(ResourceChanges, 0)
+	for _, r := range resources {
+		id := r.Change.Importing.Id
+		if id != "" {
+			acc = append(acc, r)
+		}
+	}
+	return acc
+}
+
 func (ts *TerraformState) FilterNoOpResources() {
 	acc := make(ResourceChanges, 0)
 	for _, r := range ts.ResourceChanges {
-		if len(r.Change.Actions) == 1 && r.Change.Actions[0] == "no-op" {
+		if len(r.Change.Actions) == 1 && r.Change.Actions[0] == "no-op" && r.Change.Importing.Id == "" {
 			continue
 		}
 		acc = append(acc, r)
@@ -107,8 +125,10 @@ func (ts *TerraformState) AllResourceChanges() map[string]ResourceChanges {
 	deletedResources := deletedResources(ts.ResourceChanges)
 	updatedResources := updatedResources(ts.ResourceChanges)
 	recreatedResources := recreatedResources(ts.ResourceChanges)
+	importedResources := importedResources(ts.ResourceChanges)
 
 	return map[string]ResourceChanges{
+		"import":   importedResources,
 		"add":      addedResources,
 		"delete":   deletedResources,
 		"update":   updatedResources,

--- a/terraformstate/terraform_state.go
+++ b/terraformstate/terraform_state.go
@@ -24,7 +24,7 @@ type ResourceChange struct {
 		Before    json.RawMessage `json:"before,omitempty"`
 		After     json.RawMessage `json:"after,omitempty"`
 		Importing struct {
-			Id string `json:"id"`
+			ID string `json:"id"`
 		} `json:"importing"`
 	} `json:"change"`
 	ActionReason string `json:"action_reason,omitempty"`

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -35,6 +35,10 @@ func (t Tree) IsRecreate() bool {
 	return len(t.Value.Change.Actions) == 2
 }
 
+func (t Tree) IsImport() bool {
+	return t.Value.Change.Importing.Id != ""
+}
+
 type Trees []*Tree
 
 func (t Trees) DrawableTree() *tree.Tree {

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -36,7 +36,7 @@ func (t Tree) IsRecreate() bool {
 }
 
 func (t Tree) IsImport() bool {
-	return t.Value.Change.Importing.Id != ""
+	return t.Value.Change.Importing.ID != ""
 }
 
 type Trees []*Tree

--- a/writer/json-prettyprint.go
+++ b/writer/json-prettyprint.go
@@ -18,6 +18,7 @@ type Formatter struct {
 	RemoveColor     *color.Color
 	UpdateColor     *color.Color
 	RecreateColor   *color.Color
+	ImportColor     *color.Color
 	StringMaxLength int
 	Indent          int
 	Newline         string
@@ -30,6 +31,7 @@ func NewFormatter() *Formatter {
 		RemoveColor:     color.New(color.FgRed, color.Bold),
 		UpdateColor:     color.New(color.FgYellow, color.Bold),
 		RecreateColor:   color.New(color.FgMagenta, color.Bold),
+		ImportColor:     color.New(color.FgCyan, color.Bold),
 		StringMaxLength: 0,
 		Indent:          2,
 		Newline:         "\n",

--- a/writer/json.go
+++ b/writer/json.go
@@ -40,7 +40,7 @@ func treeValue(t tree.Tree) interface{} {
 			diff = make(map[string]interface{})
 			_ = json.Unmarshal([]byte(str), &diff)
 		} else {
-			if t.IsAddition() {
+			if t.IsAddition() || t.IsImport() {
 				diff = t.Value.Change.After
 			}
 			if t.IsRemoval() {


### PR DESCRIPTION
Adds import resources to the table, tree, and json outputs. Uses Cyan color in tree view, and `(i)` to indicate an import.