### PR TITLE
Feature: differentiate between (+/-) and (-/+) in output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.21'
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
 
       -
         name: Import GPG key

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dineshba/tf-summarize
 
-go 1.20
+go 1.21
 
 require (
 	github.com/fatih/color v1.15.0

--- a/terraformstate/terraform_state_test.go
+++ b/terraformstate/terraform_state_test.go
@@ -13,7 +13,7 @@ func TestResourceChangeColor(t *testing.T) {
 		"update": ColorYellow,
 	}
 
-	for action, expected_color := range ExpectedColors {
+	for action, expectedColor := range ExpectedColors {
 		create := ResourceChange{Change: Change{Actions: []string{action}}}
 		color, _ := create.ColorPrefixAndSuffixText()
 
@@ -35,7 +35,7 @@ func TestResourceChangeSuffix(t *testing.T) {
 		"update": "(~)",
 	}
 
-	for action, expected_suffix := range ExpectedSuffix {
+	for action, expectedSuffix := range ExpectedSuffix {
 		create := ResourceChange{Change: Change{Actions: []string{action}}}
 		_, suffix := create.ColorPrefixAndSuffixText()
 

--- a/terraformstate/terraform_state_test.go
+++ b/terraformstate/terraform_state_test.go
@@ -13,7 +13,7 @@ func TestResourceChangeColor(t *testing.T) {
 		"update": ColorYellow,
 	}
 
-	for action, expectedColor := range ExpectedColors {
+	for action, expected_color := range ExpectedColors {
 		create := ResourceChange{Change: Change{Actions: []string{action}}}
 		color, _ := create.ColorPrefixAndSuffixText()
 
@@ -35,7 +35,7 @@ func TestResourceChangeSuffix(t *testing.T) {
 		"update": "(~)",
 	}
 
-	for action, expectedSuffix := range ExpectedSuffix {
+	for action, expected_suffix := range ExpectedSuffix {
 		create := ResourceChange{Change: Change{Actions: []string{action}}}
 		_, suffix := create.ColorPrefixAndSuffixText()
 

--- a/terraformstate/terraform_state_test.go
+++ b/terraformstate/terraform_state_test.go
@@ -1,0 +1,59 @@
+package terraformstate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResourceChangeColor(t *testing.T) {
+	ExpectedColors := map[string]string{
+		"create": ColorGreen,
+		"delete": ColorRed,
+		"update": ColorYellow,
+	}
+
+	for action, expected_color := range ExpectedColors {
+		create := ResourceChange{Change: Change{Actions: []string{action}}}
+		color, _ := create.ColorPrefixAndSuffixText()
+
+		assert.Equal(t, color, expected_color)
+	}
+	create := ResourceChange{Change: Change{Actions: []string{"create", "delete"}}}
+	color, _ := create.ColorPrefixAndSuffixText()
+	assert.Equal(t, color, ColorMagenta)
+
+	create = ResourceChange{Change: Change{Actions: []string{"delete", "create"}}}
+	color, _ = create.ColorPrefixAndSuffixText()
+	assert.Equal(t, color, ColorMagenta)
+}
+
+func TestResourceChangeSuffix(t *testing.T) {
+	ExpectedSuffix := map[string]string{
+		"create": "(+)",
+		"delete": "(-)",
+		"update": "(~)",
+	}
+
+	for action, expected_suffix := range ExpectedSuffix {
+		create := ResourceChange{Change: Change{Actions: []string{action}}}
+		_, suffix := create.ColorPrefixAndSuffixText()
+
+		assert.Equal(t, suffix, expected_suffix)
+	}
+	create := ResourceChange{Change: Change{Actions: []string{"create", "delete"}}}
+	_, suffix := create.ColorPrefixAndSuffixText()
+	assert.Equal(t, suffix, "(+/-)")
+
+	create = ResourceChange{Change: Change{Actions: []string{"delete", "create"}}}
+	_, suffix = create.ColorPrefixAndSuffixText()
+	assert.Equal(t, suffix, "(-/+)")
+}
+
+func TestResourceChangeColorAndSuffixImport(t *testing.T) {
+	importing := ResourceChange{Change: Change{Importing: Importing{ID: "id"}}}
+	color, suffix := importing.ColorPrefixAndSuffixText()
+
+	assert.Equal(t, color, ColorCyan)
+	assert.Equal(t, suffix, "(i)")
+}

--- a/terraformstate/terraform_state_test.go
+++ b/terraformstate/terraform_state_test.go
@@ -13,11 +13,11 @@ func TestResourceChangeColor(t *testing.T) {
 		"update": ColorYellow,
 	}
 
-	for action, expected_color := range ExpectedColors {
+	for action, expectedColor := range ExpectedColors {
 		create := ResourceChange{Change: Change{Actions: []string{action}}}
 		color, _ := create.ColorPrefixAndSuffixText()
 
-		assert.Equal(t, color, expected_color)
+		assert.Equal(t, color, expectedColor)
 	}
 	create := ResourceChange{Change: Change{Actions: []string{"create", "delete"}}}
 	color, _ := create.ColorPrefixAndSuffixText()
@@ -35,11 +35,11 @@ func TestResourceChangeSuffix(t *testing.T) {
 		"update": "(~)",
 	}
 
-	for action, expected_suffix := range ExpectedSuffix {
+	for action, expectedSuffix := range ExpectedSuffix {
 		create := ResourceChange{Change: Change{Actions: []string{action}}}
 		_, suffix := create.ColorPrefixAndSuffixText()
 
-		assert.Equal(t, suffix, expected_suffix)
+		assert.Equal(t, suffix, expectedSuffix)
 	}
 	create := ResourceChange{Change: Change{Actions: []string{"create", "delete"}}}
 	_, suffix := create.ColorPrefixAndSuffixText()


### PR DESCRIPTION
This PR adds a different suffix for "create-delete" and "delete-create", as defined by [Terraform's internal change representation.](https://developer.hashicorp.com/terraform/internals/json-format#change-representation)

"create-delete" becomes suffix `(+/-)`, "delete-create" becomes suffix `(-/+)`. Although I'm unable to reproduce "create-delete" with Terraform itself, I modified a json statefile manually and the output is as expected.

![image](https://github.com/dineshba/tf-summarize/assets/7376822/19d3cd5f-a024-4488-8f9d-20141751a7c3)

 
Closes issue #42 