### PR TITLE
ensure multiple markdown tables are rendered

### DIFF
--- a/writer/table.go
+++ b/writer/table.go
@@ -62,8 +62,10 @@ func (t TableWriter) Write(writer io.Writer) error {
 		table.AppendBulk(tableString)
 
 		if t.mdEnabled {
-			// Adding a println to break up the tables in md mode
-			fmt.Println()
+			// Without a line break separating each table, a single malformed markdown table is printed.
+			// Printing an empty newline ensures distinct, separate tables are rendered.
+			fmt.Fprint(writer, tablewriter.NEWLINE)
+
 			table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 			table.SetCenterSeparator("|")
 		} else {
@@ -77,7 +79,6 @@ func (t TableWriter) Write(writer io.Writer) error {
 }
 
 func NewTableWriter(changes map[string]terraformstate.ResourceChanges, outputChanges map[string][]string, mdEnabled bool) Writer {
-
 	return TableWriter{
 		changes:       changes,
 		mdEnabled:     mdEnabled,


### PR DESCRIPTION
This seeks to fix issue #61 by printing all output to the `io.Writer` passed to `writer.TableWriter#Write`. This ensures multiple, distinct markdown tables are printed, even when `tf-summarize` is invoked with both `-md` and `-out` flags.

Previously, `fmt.Println()` was used to separate the markdown tables, but this is insufficient when `-out` is used with a non-STDOUT writer, as is the case when writing output to a `-out`-specified file.