### PR TITLE
feat: add support for env defined binary

### DIFF
--- a/parser/binary-parser.go
+++ b/parser/binary-parser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 
 	tfjson "github.com/hashicorp/terraform-json"
@@ -13,7 +14,11 @@ type BinaryParser struct {
 }
 
 func (j BinaryParser) Parse() (tfjson.Plan, error) {
-	cmd := exec.Command("terraform", "show", "-json", j.fileName)
+	tfbinary := "terraform"
+	if tfoverride, ok := os.LookupEnv("TF_BINARY"); ok {
+		tfbinary = tfoverride
+	}
+	cmd := exec.Command(tfbinary, "show", "-json", j.fileName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return tfjson.Plan{}, fmt.Errorf(


### PR DESCRIPTION
Resolves #67

## Changes

Resolves a `TF_BINARY` environment variable that tells us what command to execute. Still assumes it's on the path so no behavioural difference.
Defaults to `terraform` for backwards compatibility.

## Notes

- Choice of `TF_BINARY` was pretty arbitrary.
- I'm not primarily a go dev and there didn't seem to be an standardised way of `get_env_or_default` equivalent.
- I tested locally by executing the output from `make build` manually (so no additional tests).

