### PR TITLE
Fix incorrect filtering of no-op changes

### DIFF
--- a/terraformstate/terraform_state.go
+++ b/terraformstate/terraform_state.go
@@ -92,7 +92,7 @@ func importedResources(resources ResourceChanges) ResourceChanges {
 func FilterNoOpResources(ts *tfjson.Plan) {
 	acc := make(ResourceChanges, 0)
 	for _, r := range ts.ResourceChanges {
-		if len(r.Change.Actions) == 1 && r.Change.Actions[0] == "no-op" && r.Change.Importing != nil && r.Change.Importing.ID == "" {
+		if len(r.Change.Actions) == 1 && r.Change.Actions[0] == "no-op" && (r.Change.Importing == nil || r.Change.Importing.ID == "") {
 			continue
 		}
 		acc = append(acc, r)

--- a/terraformstate/terraform_state_test.go
+++ b/terraformstate/terraform_state_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/hashicorp/terraform-json"
+	tfjson "github.com/hashicorp/terraform-json"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -58,4 +59,21 @@ func TestResourceChangeColorAndSuffixImport(t *testing.T) {
 
 	assert.Equal(t, color, ColorCyan)
 	assert.Equal(t, suffix, "(i)")
+}
+
+func TestFilterNoOpResources(t *testing.T) {
+	resourceChanges := ResourceChanges{
+		&ResourceChange{Address: "no-op1", Change: &Change{Actions: Actions{ActionNoop}}},
+		&ResourceChange{Address: "no-op3", Change: &Change{Actions: Actions{ActionNoop}, Importing: nil}},
+		&ResourceChange{Address: "no-op2", Change: &Change{Actions: Actions{ActionNoop}, Importing: &Importing{ID: ""}}},
+		&ResourceChange{Address: "create", Change: &Change{Actions: Actions{ActionCreate}}},
+	}
+	plan := tfjson.Plan{ResourceChanges: resourceChanges}
+
+	FilterNoOpResources(&plan)
+
+	expectedResourceChangesAfterFiltering := ResourceChanges{
+		&ResourceChange{Address: "create", Change: &Change{Actions: Actions{ActionCreate}}},
+	}
+	assert.Equal(t, expectedResourceChangesAfterFiltering, plan.ResourceChanges)
 }


### PR DESCRIPTION
Fixes issue #71 

```
❯ ../tf-summarize --tree changes.tfplan
|---random_id
|       |---b(-/+)
|       |---c(+)

❯ ../tf-summarize  changes.tfplan
+----------+-------------+
|  CHANGE  |  RESOURCE   |
+----------+-------------+
| add      | random_id.c |
+----------+-------------+
| recreate | random_id.b |
+----------+-------------+
```