### PR TITLE
Sort results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,9 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.21"
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: latest
+          
+      - name: Linter
+        uses: docker://morphy/revive-action:v2
 
       - name: Test
         run: go test -v ./...

--- a/terraformstate/terraform_state.go
+++ b/terraformstate/terraform_state.go
@@ -3,6 +3,7 @@ package terraformstate
 import (
 	"encoding/json"
 	"fmt"
+        "sort"
 
 	tfjson "github.com/hashicorp/terraform-json"
 )
@@ -107,6 +108,18 @@ func GetAllResourceChanges(plan tfjson.Plan) map[string]ResourceChanges {
 	recreatedResources := recreatedResources(plan.ResourceChanges)
 	importedResources := importedResources(plan.ResourceChanges)
 
+	sortResources := func(resources ResourceChanges) {
+		sort.Slice(resources, func(i, j int) bool {
+			return resources[i].Address < resources[j].Address
+		})
+	}
+	
+	sortResources(addedResources)
+	sortResources(deletedResources)
+	sortResources(updatedResources)
+	sortResources(recreatedResources)
+	sortResources(importedResources)
+	
 	return map[string]ResourceChanges{
 		"import":   importedResources,
 		"add":      addedResources,
@@ -122,7 +135,11 @@ func GetAllOutputChanges(plan tfjson.Plan) map[string][]string {
 	addedResources := filterOutputs(plan.OutputChanges, "create")
 	deletedResources := filterOutputs(plan.OutputChanges, "delete")
 	updatedResources := filterOutputs(plan.OutputChanges, "update")
-
+    
+	sort.Strings(addedResources)
+    	sort.Strings(deletedResources)
+    	sort.Strings(updatedResources)
+	
 	return map[string][]string{
 		"add":    addedResources,
 		"delete": deletedResources,

--- a/terraformstate/terraform_state.go
+++ b/terraformstate/terraform_state.go
@@ -3,7 +3,7 @@ package terraformstate
 import (
 	"encoding/json"
 	"fmt"
-        "sort"
+	"sort"
 
 	tfjson "github.com/hashicorp/terraform-json"
 )
@@ -113,13 +113,13 @@ func GetAllResourceChanges(plan tfjson.Plan) map[string]ResourceChanges {
 			return resources[i].Address < resources[j].Address
 		})
 	}
-	
+
 	sortResources(addedResources)
 	sortResources(deletedResources)
 	sortResources(updatedResources)
 	sortResources(recreatedResources)
 	sortResources(importedResources)
-	
+
 	return map[string]ResourceChanges{
 		"import":   importedResources,
 		"add":      addedResources,
@@ -135,11 +135,11 @@ func GetAllOutputChanges(plan tfjson.Plan) map[string][]string {
 	addedResources := filterOutputs(plan.OutputChanges, "create")
 	deletedResources := filterOutputs(plan.OutputChanges, "delete")
 	updatedResources := filterOutputs(plan.OutputChanges, "update")
-    
+
 	sort.Strings(addedResources)
-    	sort.Strings(deletedResources)
-    	sort.Strings(updatedResources)
-	
+	sort.Strings(deletedResources)
+	sort.Strings(updatedResources)
+
 	return map[string][]string{
 		"add":    addedResources,
 		"delete": deletedResources,

--- a/terraformstate/terraform_state_test.go
+++ b/terraformstate/terraform_state_test.go
@@ -22,6 +22,7 @@ func TestResourceChangeColor(t *testing.T) {
 
 		assert.Equal(t, color, expectedColor)
 	}
+
 	CreateDelete := &ResourceChange{Change: &Change{Actions: []Action{ActionCreate, ActionDelete}}}
 	color, _ := GetColorPrefixAndSuffixText(CreateDelete)
 	assert.Equal(t, color, ColorMagenta)

--- a/terraformstate/terraform_state_test.go
+++ b/terraformstate/terraform_state_test.go
@@ -32,6 +32,73 @@ func TestResourceChangeColor(t *testing.T) {
 	assert.Equal(t, color, ColorMagenta)
 }
 
+func TestGetAllResourceChanges(t *testing.T) {
+	resourceChanges := ResourceChanges{
+		&ResourceChange{Address: "create2", Change: &Change{Actions: Actions{ActionCreate}}},
+		&ResourceChange{Address: "create1", Change: &Change{Actions: Actions{ActionCreate}}},
+		&ResourceChange{Address: "delete2", Change: &Change{Actions: Actions{ActionDelete}}},
+		&ResourceChange{Address: "delete1", Change: &Change{Actions: Actions{ActionDelete}}},
+		&ResourceChange{Address: "update2", Change: &Change{Actions: Actions{ActionUpdate}}},
+		&ResourceChange{Address: "update1", Change: &Change{Actions: Actions{ActionUpdate}}},
+		&ResourceChange{Address: "import2", Change: &Change{Importing: &Importing{ID: "id1"}}},
+		&ResourceChange{Address: "import1", Change: &Change{Importing: &Importing{ID: "id2"}}},
+		&ResourceChange{Address: "recreate2", Change: &Change{Actions: Actions{ActionDelete, ActionCreate}}},
+		&ResourceChange{Address: "recreate1", Change: &Change{Actions: Actions{ActionDelete, ActionCreate}}},
+	}
+	plan := tfjson.Plan{ResourceChanges: resourceChanges}
+
+	result := GetAllResourceChanges(plan)
+
+	expectedResourceChanges := map[string]ResourceChanges{
+		"add": {
+			&ResourceChange{Address: "create1", Change: &Change{Actions: Actions{ActionCreate}}},
+			&ResourceChange{Address: "create2", Change: &Change{Actions: Actions{ActionCreate}}},
+		},
+		"delete": {
+			&ResourceChange{Address: "delete1", Change: &Change{Actions: Actions{ActionDelete}}},
+			&ResourceChange{Address: "delete2", Change: &Change{Actions: Actions{ActionDelete}}},
+		},
+		"update": {
+			&ResourceChange{Address: "update1", Change: &Change{Actions: Actions{ActionUpdate}}},
+			&ResourceChange{Address: "update2", Change: &Change{Actions: Actions{ActionUpdate}}},
+		},
+		"recreate": {
+			&ResourceChange{Address: "recreate1", Change: &Change{Actions: Actions{ActionDelete, ActionCreate}}},
+			&ResourceChange{Address: "recreate2", Change: &Change{Actions: Actions{ActionDelete, ActionCreate}}},
+		},
+		"import": {
+			&ResourceChange{Address: "import1", Change: &Change{Importing: &Importing{ID: "id2"}}},
+			&ResourceChange{Address: "import2", Change: &Change{Importing: &Importing{ID: "id1"}}},
+		},
+	}
+
+	assert.Equal(t, expectedResourceChanges, result)
+}
+
+func TestGetAllOutputChanges(t *testing.T) {
+
+	outputChanges := map[string]*Change{
+		"create2": {Actions: Actions{ActionCreate}},
+		"create1": {Actions: Actions{ActionCreate}},
+		"delete2": {Actions: Actions{ActionDelete}},
+		"delete1": {Actions: Actions{ActionDelete}},
+		"update2": {Actions: Actions{ActionUpdate}},
+		"update1": {Actions: Actions{ActionUpdate}},
+	}
+
+	plan := tfjson.Plan{OutputChanges: outputChanges}
+
+	result := GetAllOutputChanges(plan)
+
+	expectedResourceChanges := map[string][]string{
+		"add":    {"create1", "create2"},
+		"delete": {"delete1", "delete2"},
+		"update": {"update1", "update2"},
+	}
+
+	assert.Equal(t, expectedResourceChanges, result)
+}
+
 func TestResourceChangeSuffix(t *testing.T) {
 	ExpectedSuffix := map[Action]string{
 		ActionCreate: "(+)",


### PR DESCRIPTION
Dealing with larger plans is harder if results are not sorted.

- Replaced deprecated Linter
- Added sorting logic
- Added test to cover `GetAllOutputChanges` and `GetAllResourceChanges`