### PR TITLE
Print raw diff when there is error during jsonDiff for -json flag

### DIFF
--- a/writer/json.go
+++ b/writer/json.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/dineshba/tf-summarize/terraformstate"
 	"github.com/dineshba/tf-summarize/tree"
@@ -40,7 +41,11 @@ func treeValue(t tree.Tree) interface{} {
 			after, _ := json.Marshal(t.Value.Change.After)
 			_, str := jsondiff.Compare(before, after, &opts)
 			diff = make(map[string]interface{})
-			_ = json.Unmarshal([]byte(str), &diff)
+			err := json.Unmarshal([]byte(str), &diff)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: unmarshalling diff error: %s\n", err)
+				diff = fmt.Sprintf("raw diff: %s", str)
+			}
 		} else {
 			if t.IsAddition() || t.IsImport() {
 				diff = t.Value.Change.After


### PR DESCRIPTION
It is a short-term fix to show raw string and show warning in stderr where is there json diff error for -json flag #26.

Long term fix: Need to investigate on this and parse it properly and show the diff

Issue details:
- I am able to reproduce this issue only when the metadata field in the helm release is removed. For other changes it is able to easily handle. In the below file, if we remove metadata from either before or change resource changes, it is failing and printing empty. So, as short term, during this error showing the raw string.

[tfplan.json](https://github.com/user-attachments/files/17506010/tfplan.json)
