### PR TITLE
85: Add resouce count to change summary

### DIFF
--- a/testdata/basic.html
+++ b/testdata/basic.html
@@ -4,7 +4,7 @@
     <th>RESOURCE</th>
   </tr>
   <tr>
-    <td>add</td>
+    <td>add (7)</td>
     <td>
       <ul>
         <li><code>github_repository.terraform_plan_summary</code></li>
@@ -24,7 +24,7 @@
     <th>OUTPUT</th>
   </tr>
   <tr>
-    <td>add</td>
+    <td>add (1)</td>
     <td>
       <ul>
         <li><code>terraform_plan_summary_repository_name</code></li>

--- a/testdata/basic.txt
+++ b/testdata/basic.txt
@@ -1,13 +1,13 @@
-| CHANGE |                                RESOURCE                                |
-|--------|------------------------------------------------------------------------|
-| add    | `github_repository.terraform_plan_summary`                             |
-|        | `module.github["demo-repository"].github_branch.development`           |
-|        | `module.github["demo-repository"].github_branch.main`                  |
-|        | `module.github["demo-repository"].github_repository.repository`        |
-|        | `module.github["terraform-plan-summary"].github_branch.development`    |
-|        | `module.github["terraform-plan-summary"].github_branch.main`           |
-|        | `module.github["terraform-plan-summary"].github_repository.repository` |
+| CHANGE  |                                RESOURCE                                |
+|---------|------------------------------------------------------------------------|
+| add (7) | `github_repository.terraform_plan_summary`                             |
+|         | `module.github["demo-repository"].github_branch.development`           |
+|         | `module.github["demo-repository"].github_branch.main`                  |
+|         | `module.github["demo-repository"].github_repository.repository`        |
+|         | `module.github["terraform-plan-summary"].github_branch.development`    |
+|         | `module.github["terraform-plan-summary"].github_branch.main`           |
+|         | `module.github["terraform-plan-summary"].github_repository.repository` |
 
-| CHANGE |                  OUTPUT                  |
-|--------|------------------------------------------|
-| add    | `terraform_plan_summary_repository_name` |
+| CHANGE  |                  OUTPUT                  |
+|---------|------------------------------------------|
+| add (1) | `terraform_plan_summary_repository_name` |

--- a/writer/html_test.go
+++ b/writer/html_test.go
@@ -19,7 +19,7 @@ func TestHTMLWriterWithMockFileSystem(t *testing.T) {
     <th>RESOURCE</th>
   </tr>{{ range $change, $resources := .ResourceChanges }}{{ $length := len $resources }}{{ if gt $length 0 }}
   <tr>
-    <td>{{ $change }}</td>
+    <td>{{ $change }} ({{ len $resources }})</td>
     <td>
       <ul>{{ range $i, $r := $resources }}
         <li><code>{{ $r.Address }}</code></li>{{ end }}

--- a/writer/table.go
+++ b/writer/table.go
@@ -20,11 +20,12 @@ func (t TableWriter) Write(writer io.Writer) error {
 	tableString := make([][]string, 0, 4)
 	for _, change := range tableOrder {
 		changedResources := t.changes[change]
+		resourceCount := len(changedResources)
 		for _, changedResource := range changedResources {
 			if t.mdEnabled {
-				tableString = append(tableString, []string{change, fmt.Sprintf("`%s`", changedResource.Address)})
+				tableString = append(tableString, []string{fmt.Sprintf("%s (%d)", change, resourceCount), fmt.Sprintf("`%s`", changedResource.Address)})
 			} else {
-				tableString = append(tableString, []string{change, changedResource.Address})
+				tableString = append(tableString, []string{fmt.Sprintf("%s (%d)", change, resourceCount), changedResource.Address})
 			}
 		}
 	}
@@ -49,11 +50,12 @@ func (t TableWriter) Write(writer io.Writer) error {
 		tableString = make([][]string, 0, 4)
 		for _, change := range tableOrder {
 			changedOutputs := t.outputChanges[change]
+			outputCount := len(changedOutputs)
 			for _, changedOutput := range changedOutputs {
 				if t.mdEnabled {
-					tableString = append(tableString, []string{change, fmt.Sprintf("`%s`", changedOutput)})
+					tableString = append(tableString, []string{fmt.Sprintf("%s (%d)", change, outputCount), fmt.Sprintf("`%s`", changedOutput)})
 				} else {
-					tableString = append(tableString, []string{change, changedOutput})
+					tableString = append(tableString, []string{fmt.Sprintf("%s (%d)", change, outputCount), changedOutput})
 				}
 			}
 		}

--- a/writer/templates/outputChanges.html
+++ b/writer/templates/outputChanges.html
@@ -4,7 +4,7 @@
     <th>OUTPUT</th>
   </tr>{{ range $change, $outputs := .OutputChanges }}{{ $length := len $outputs }}{{ if gt $length 0 }}
   <tr>
-    <td>{{ $change }}</td>
+    <td>{{ $change }} ({{ len $outputs }})</td>
     <td>
       <ul>{{ range $i, $o := $outputs }}
         <li><code>{{ $o }}</code></li>{{ end }}

--- a/writer/templates/resourceChanges.html
+++ b/writer/templates/resourceChanges.html
@@ -4,7 +4,7 @@
     <th>RESOURCE</th>
   </tr>{{ range $change, $resources := .ResourceChanges }}{{ $length := len $resources }}{{ if gt $length 0 }}
   <tr>
-    <td>{{ $change }}</td>
+    <td>{{ $change }} ({{ len $resources }})</td>
     <td>
       <ul>{{ range $i, $r := $resources }}
         <li><code>{{ $r.Address }}</code></li>{{ end }}


### PR DESCRIPTION
## Change

Update for issue #85 to add the number of changed resources or outputs to the summary reports.

### Note
This did not get linted because when I installed `golanglint-ci` it was a newer version (`2.1.2`) and wanted to update the `.golangci.yaml` file.  I'll leave that to you.
Directly running `go test` passes.