### PR TITLE
ci: publish multi-arch (amd64 + arm64) docker images

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -32,6 +32,12 @@ jobs:
           name: coverage-report
           path: coverage.out
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Build
         run: make
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,6 @@ dockers:
   image_templates:
     - ghcr.io/dineshba/tf-summarize:{{ .Version }}-amd64
     - ghcr.io/dineshba/tf-summarize:latest-amd64
-    - ghcr.io/dineshba/tf-summarize:latest
   build_flag_templates:
     - "--label=org.opencontainers.image.created={{ .Date }}"
     - "--label=org.opencontainers.image.title={{ .ProjectName }}"
@@ -24,6 +23,30 @@ dockers:
   goarch: amd64
   goamd64: v1
   use: buildx
+- dockerfile: Dockerfile
+  image_templates:
+    - ghcr.io/dineshba/tf-summarize:{{ .Version }}-arm64
+    - ghcr.io/dineshba/tf-summarize:latest-arm64
+  build_flag_templates:
+    - "--label=org.opencontainers.image.created={{ .Date }}"
+    - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+    - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+    - "--label=org.opencontainers.image.version={{ .Version }}"
+    - "--platform=linux/arm64"
+    - "--target=goreleaser"
+    - "--pull"
+  goos: linux
+  goarch: arm64
+  use: buildx
+docker_manifests:
+- name_template: ghcr.io/dineshba/tf-summarize:{{ .Version }}
+  image_templates:
+    - ghcr.io/dineshba/tf-summarize:{{ .Version }}-amd64
+    - ghcr.io/dineshba/tf-summarize:{{ .Version }}-arm64
+- name_template: ghcr.io/dineshba/tf-summarize:latest
+  image_templates:
+    - ghcr.io/dineshba/tf-summarize:latest-amd64
+    - ghcr.io/dineshba/tf-summarize:latest-arm64
 builds:
   - env:
       # goreleaser does not work with CGO, it could also complicate

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ asdf install tf-summarize latest
 > See the asdf [plugin source](https://github.com/adamcrews/asdf-tf-summarize#install) for more information.
 
 #### Using Docker
+
+The published images are multi-arch and run natively on both `linux/amd64` and `linux/arm64`.
 ```sh
 docker run -v $PWD:/workspace -w /workspace ghcr.io/dineshba/tf-summarize -v # prints version
 docker run -v $PWD:/workspace -w /workspace ghcr.io/dineshba/tf-summarize tfplan.json


### PR DESCRIPTION
Add a linux/arm64 docker build and docker_manifests so the published ghcr.io/dineshba/tf-summarize :latest and :{{ .Version }} tags resolve to a multi-arch manifest covering both amd64 and arm64.

The per-arch images are tagged with -amd64/-arm64 suffixes and combined via docker_manifests; the previously single-arch :latest tag is now the manifest list instead of an amd64-only image.

The PR build job runs the goreleaser snapshot build (make), which now cross-builds the arm64 image, so QEMU + buildx setup is added to that job (the release job already had them).

## Summary
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature (new output format, input source, etc.)
- [ ] Refactor (no behavior change)
- [ ] CI/CD or build change
- [ ] Documentation

## Changes
<!-- List the key changes made -->
-

## Testing
<!-- How was this tested? -->
- [ ] Unit tests added/updated
- [ ] Integration tests pass (`make test`)
- [ ] Manual testing with sample tfplan

## Checklist
- [ ] Code follows project conventions (see `.instructions.md`)
- [ ] `make lint` passes
- [ ] `make gosec` passes
- [ ] No breaking changes to CLI flags or output formats
